### PR TITLE
Better logging formatting + Moving Lint to source file instead of generated files

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,35 +1,35 @@
 'use strict';
 var fs = require('fs'),
-    path = require('path'),
-    async = require('async'),
-    LOG = require('winston'),
-    glob = require('glob'),
-    chalk = require('chalk'),
-    templates = require('./templates.js'),
-    //! alias = require('./alias'),
-    _ = require('lodash'),
-    jsonminify = require('jsonminify'),
-    rimraf = require('rimraf'),
-    EOL = require('os').EOL,
-    exec = require('./utils/executor'),
-    copier = require('./utils/copier'),
-    meta = require('./utils/meta'),
-    writer = require('./writer'),
-    linter = require('./lint/linter'),
-    rollups = [],
-    config = {},
-    lintConfig = {},
-    defaultConfig = {
-      regex: '^(?!\\s*?\\*).*(?:Y.log)(.*\n*)*?.*\\);.*|^.*?(?:/\\*@DBG\\*/).*\\r?\\n|^.*?(?:/\\*@DBG@\\*/).*\\r?\\n',
-      target: path.join(process.cwd(), 'target')
-    };
+  path = require('path'),
+  async = require('async'),
+  LOG = require('winston'),
+  glob = require('glob'),
+  chalk = require('chalk'),
+  templates = require('./templates.js'),
+  //! alias = require('./alias'),
+  _ = require('lodash'),
+  jsonminify = require('jsonminify'),
+  rimraf = require('rimraf'),
+  EOL = require('os').EOL,
+  exec = require('./utils/executor'),
+  copier = require('./utils/copier'),
+  meta = require('./utils/meta'),
+  writer = require('./writer'),
+  linter = require('./lint/linter'),
+  rollups = [],
+  config = {},
+  lintConfig = {},
+  defaultConfig = {
+    regex: '^(?!\\s*?\\*).*(?:Y.log)(.*\n*)*?.*\\);.*|^.*?(?:/\\*@DBG\\*/).*\\r?\\n|^.*?(?:/\\*@DBG@\\*/).*\\r?\\n',
+    target: path.join(process.cwd(), 'target')
+  };
 
 /**! Replace the content with the given keys.
  * @param content {string} The current content.
  * @param keys {array} The keys to be replaced.
  */
 function replace(content, keys) {
-  _.forEach(_.merge(config, keys || {}), function(value, key) {
+  _.forEach(_.merge(config, keys || {}), function (value, key) {
     // If the key does not have ```@key@```, it will be added.
     if (key.indexOf('\@') != 0) {
       key = '\@' + key + '\@';
@@ -76,7 +76,7 @@ var builder = {
    * @param options {object} The given options for the builder.
    * @param lintOptions {object} The jshint options.
    */
-  load: function(options, lintOptions) {
+  load: function (options, lintOptions) {
     // Merge the options with the default options.
     config = _.merge(defaultConfig, options || {});
     lintConfig = lintOptions || {};
@@ -89,7 +89,7 @@ var builder = {
    * @param base {string} The base path.
    * @param callback {function} The callback to be called with the results.
    */
-  build: function(base, callback) {
+  build: function (base, callback) {
     // Search for every available module under the base path. ```Reverse``` is added to be compatible with ```shifter```.
     var files = glob.sync(path.join(base, '**', 'build.json')).reverse(),
       each = async.eachLimit;
@@ -106,7 +106,7 @@ var builder = {
     //!   each = async.eachSeries;
     //! }
 
-    each(files, 20, builder.buildModule, function(err) {
+    each(files, 20, builder.buildModule, function (err) {
       if (err) {
         callback(err);
       }
@@ -118,7 +118,7 @@ var builder = {
    * @param file {string} The ```build.json``` file.
    * @param next {function} The callback to be called when the build is done.
    */
-  buildModule: function(file, next) {
+  buildModule: function (file, next) {
     var descriptor = JSON.parse(fs.readFileSync(file)),
       base = path.dirname(file),
       cache,
@@ -130,10 +130,10 @@ var builder = {
     if (descriptor.prebuilds) {
       // Save the current descriptor to be used when the prebuilds are done.
       cache = descriptor;
-      _.forEach(descriptor.prebuilds, function(prebuild) {
+      _.forEach(descriptor.prebuilds, function (prebuild) {
         LOG.debug('prebuild: ' + prebuild);
         // Build the prebuilds
-        builder.buildModule(path.join(base, '..', prebuild, 'build.json'), function(err) {
+        builder.buildModule(path.join(base, '..', prebuild, 'build.json'), function (err) {
           if (err) {
             LOG.debug(JSON.stringify(descriptor));
             throw new Error(err);
@@ -164,7 +164,7 @@ var builder = {
 
     // Add the rollups to the rollups object so they can be build after the current build.
     if (descriptor.rollups) {
-      _.forEach(descriptor.rollups, function(rollup, name) {
+      _.forEach(descriptor.rollups, function (rollup, name) {
         // Set the rollup name.
         if (!rollup.name && !rollup.basefilename) {
           rollup.name = name;
@@ -183,7 +183,7 @@ var builder = {
     }
 
     // Build each files.
-    _.forEach(descriptor.builds, function(build, name) {
+    _.forEach(descriptor.builds, function (build, name) {
       if (typeof build === 'string') {
         return;
       }
@@ -210,7 +210,7 @@ var builder = {
           // Build as css module.
           builder.css(name, build.cssfiles, properties, base);
         }
-      } catch(e) {
+      } catch (e) {
         // If something went wrong, the ```next``` function is called with an error.
         next(e);
       }
@@ -239,10 +239,10 @@ var builder = {
 
     // Run the postbuilds for the current build.
     if (descriptor.postbuilds) {
-      _.forEach(descriptor.postbuilds, function(prebuild) {
+      _.forEach(descriptor.postbuilds, function (prebuild) {
         LOG.debug('postbuilds: ' + prebuild);
         // Build the postbuilds
-        builder.buildModule(path.join(base, '..', prebuild, 'build.json'), function(err) {
+        builder.buildModule(path.join(base, '..', prebuild, 'build.json'), function (err) {
           if (err) {
             throw new Error(err);
           }
@@ -257,21 +257,21 @@ var builder = {
    * @param file {string} The ```build.json``` file.
    * @param next {function} The callback to be called when the build is done.
    */
-  rollup: function(callback) {
+  rollup: function (callback) {
     LOG.info('Building rollups');
-    async.each(rollups, function(rollup) {
-      var content= '',
+    async.each(rollups, function (rollup) {
+      var content = '',
         filename = rollup.basefilename || rollup.name;
       LOG.info('Creating rollup: ' + filename);
 
-      _.forEach(rollup.files, function(file) {
+      _.forEach(rollup.files, function (file) {
         var filePath,
           basePath = path.join(config.target, file);
 
         // Check if the rollup needs the language files.
         if (rollup.lang) {
           // Go through the languages and add it to the rollup.
-          _.forEach(rollup.lang, function(lang) {
+          _.forEach(rollup.lang, function (lang) {
             content = append(content, path.join(basePath, 'lang', file + '_' + lang + '.js'));
           });
         }
@@ -309,7 +309,7 @@ var builder = {
    * @param properties {obejct} The properties for the module.
    * @param base {string} The base path for the module.
    */
-  js: function(name, files, properties, base) {
+  js: function (name, files, properties, base) {
     var content = "",
       valid,
       data = {
@@ -325,7 +325,7 @@ var builder = {
 
     // If lang is present, add lang to the template data.
     if (properties.lang) {
-      data.lang= JSON.stringify(properties.lang, null, 2).replace(/\"/g, '\'');
+      data.lang = JSON.stringify(properties.lang, null, 2).replace(/\"/g, '\'');
     }
 
     // This is not documented in shifter but used in autocomplete-base.
@@ -343,11 +343,20 @@ var builder = {
       data.config = JSON.stringify(properties.config).slice(1, -1).replace(/\"/g, '\'');
     }
 
-    // Concatenate all the javascript files.
-    _.forEach(files, function(file) {
-      var filePath = checkPath(base, file, 'js');
+    // Lint and Concatenate all the javascript files.
+    _.forEach(files, function (file) {
+      var tmpBuff, filePath = checkPath(base, file, 'js');
       if (fs.existsSync(filePath)) {
-        content += fs.readFileSync(filePath, 'utf8');
+        tmpBuff = fs.readFileSync(filePath, 'utf8');
+        // If the file is not auto-generated and lint is not disabled, run lint.
+        if (!generated && properties.parent.lint !== false && config.lint !== false) {
+          valid = linter.verify(config.linter, tmpBuff, lintConfig, name);
+          // If jshint fails and the properties does not cover it, fail the build.
+          if (!valid && properties.fail !== false && properties.parent.fail !== false && config.fail !== false) {
+            throw new Error('Lint failed for module ' + name);
+          }
+        }
+        content += tmpBuff;
       }
     });
 
@@ -363,7 +372,7 @@ var builder = {
 
     // Preapend files defined by the properties.
     if (properties.prependfiles) {
-      _.forEach(properties.prependfiles, function(append) {
+      _.forEach(properties.prependfiles, function (append) {
         var fileContent = fs.readFileSync(checkPath(base, append, 'js'), 'utf8');
         content = fileContent + EOL + content;
       });
@@ -371,7 +380,7 @@ var builder = {
 
     // Append files defined by the properties.
     if (properties.appendfiles) {
-      _.forEach(properties.appendfiles, function(append) {
+      _.forEach(properties.appendfiles, function (append) {
         var fileContent = fs.readFileSync(checkPath(base, append, 'js'), 'utf8');
         content = content + EOL + fileContent;
       });
@@ -379,14 +388,6 @@ var builder = {
 
     // Replace all the ```replace--XXX``` properties.
     content = replace(content, properties.replace);
-    // If the files are not auto-generated and the lint is present, run jshint.
-    if (!generated && properties.parent.lint !== false && config.lint !== false) {
-      valid = linter.verify(config.linter, content, lintConfig, name);
-      // If jshint fails and the properties does not cover it, fail the build.
-      if (!valid && properties.fail !== false && properties.parent.fail !== false && config.fail !== false) {
-        throw new Error('JSHINT failed for module ' + name);
-      }
-    }
 
     if (!config.dry) {
       // Write the output files.
@@ -417,56 +418,56 @@ var builder = {
    * @param base {string} The base path for the module.
    * @param properties {obejct} The properties for the module.
    */
-  skin: function(name, filename, base, properties) {
+  skin: function (name, filename, base, properties) {
     var basePath = path.join(base, 'assets'),
       skinPath = path.join(basePath, 'skins'),
       corePath = path.join(basePath, name + '-core.css'),
       core = '',
       skins;
 
-      /** Search for the skin folder. There are two options:
-       * * base path + skins (for simple module).
-       * * base path + module name + skins (for modules with submodules that contains skins).
-       */
+    /** Search for the skin folder. There are two options:
+     * * base path + skins (for simple module).
+     * * base path + module name + skins (for modules with submodules that contains skins).
+     */
+    if (!fs.existsSync(skinPath)) {
+      skinPath = path.join(basePath, name, 'skins');
+      corePath = path.join(basePath, name, name + '-core.css');
       if (!fs.existsSync(skinPath)) {
-        skinPath = path.join(basePath, name, 'skins');
-        corePath = path.join(basePath, name, name + '-core.css');
-        if (!fs.existsSync(skinPath)) {
-          // If the skin is not present return.
-          LOG.error(name + ' does not have a skin, please remove the skinnable attribute.');
-          return;
-        }
+        // If the skin is not present return.
+        LOG.error(name + ' does not have a skin, please remove the skinnable attribute.');
+        return;
       }
+    }
 
-      skins = fs.readdirSync(skinPath);
-      // Core css is not needed in the output.
-      //! mkdirp.sync(path.join(config.target, filename, 'assets', 'skins'));
-      if (fs.existsSync(corePath)) {
-        core = fs.readFileSync(corePath);
-        //! fs.writeFileSync(path.join(config.target, filename, 'assets', filename + '-core.css'), core, 'utf8');
+    skins = fs.readdirSync(skinPath);
+    // Core css is not needed in the output.
+    //! mkdirp.sync(path.join(config.target, filename, 'assets', 'skins'));
+    if (fs.existsSync(corePath)) {
+      core = fs.readFileSync(corePath);
+      //! fs.writeFileSync(path.join(config.target, filename, 'assets', filename + '-core.css'), core, 'utf8');
+    }
+
+    /** Run the same procedure for each skin.
+     * * Concatenate the core and the current skin.
+     * * Apply the ```YUI``` template for css.
+     * * Uglify and minify
+     */
+    _.forEach(skins, function (skin) {
+      var currentSkin = path.join(skinPath, skin, name + '-skin.css'),
+        targetPath = path.join(config.target, filename, 'assets', 'skins', skin),
+        skinContent,
+        content;
+
+      // If the skin exists, build it.
+      if (fs.existsSync(currentSkin)) {
+        skinContent = fs.readFileSync(currentSkin);
+        content = core + EOL + skinContent;
+        // Build the css files.
+        builder.buildCss(content, targetPath, filename, name, properties);
+      } else {
+        LOG.debug('%s does not exist', currentSkin)
       }
-
-      /** Run the same procedure for each skin.
-       * * Concatenate the core and the current skin.
-       * * Apply the ```YUI``` template for css.
-       * * Uglify and minify
-       */
-      _.forEach(skins, function(skin) {
-        var currentSkin = path.join(skinPath, skin, name + '-skin.css'),
-          targetPath = path.join(config.target, filename, 'assets', 'skins', skin),
-          skinContent,
-          content;
-
-        // If the skin exists, build it.
-        if (fs.existsSync(currentSkin)) {
-          skinContent = fs.readFileSync(currentSkin);
-          content = core + EOL + skinContent;
-          // Build the css files.
-          builder.buildCss(content, targetPath, filename, name, properties);
-        } else {
-          LOG.debug('%s does not exist', currentSkin)
-        }
-      });
+    });
   },
 
   /**! Build the css module.
@@ -475,14 +476,14 @@ var builder = {
    * @param properties {obejct} The properties for the module.
    * @param base {string} The base path for the module.
    */
-  css: function(name, files, properties, base) {
+  css: function (name, files, properties, base) {
     var content,
       data = [],
       filename = properties.basefilename || name,
       targetPath = path.join(config.target, filename);
 
     // Read and accumlate all the files.
-    _.forEach(files, function(file) {
+    _.forEach(files, function (file) {
       var filePath = checkPath(base, file, 'css');
       if (fs.existsSync(filePath)) {
         data.push(fs.readFileSync(filePath, 'utf8'));
@@ -504,7 +505,7 @@ var builder = {
    * @param properties {obejct} The properties for the module.
    * @param callback {function} The callback to be called with the results.
    */
-  buildCss: function(data, targetPath, filename, moduleName, properties, callback) {
+  buildCss: function (data, targetPath, filename, moduleName, properties, callback) {
     // Replace all the ```replace--XXX``` properties.
     var content = replace(data, properties.replace),
       valid;

--- a/lib/lint/reporters/eslint.js
+++ b/lib/lint/reporters/eslint.js
@@ -22,22 +22,24 @@ var reporter = {
    * @param name {string} The name of the module.
    */
   report: function (messages, name) {
-    console.log();
-    logger.info(chalk.cyan('ESLint: ' + name));
-    _.forEach(messages, function (message) {
-      var rule, type = message.severity > 1 ? 'error' : 'warning';
+    if (!_.isEmpty(messages)) {
+      console.log();
+      logger.info(chalk.cyan('ESLint: ' + name));
+      _.forEach(messages, function (message) {
+        var rule, type = message.severity > 1 ? 'error' : 'warning';
 
-      if (message.message && message.message.trim().length) {
-        rule = message.message;
-      }
-      if (message.ruleId && message.ruleId.trim().length) {
-        rule += ' (' + message.ruleId + ')';
-      }
+        if (message.message && message.message.trim().length) {
+          rule = message.message;
+        }
+        if (message.ruleId && message.ruleId.trim().length) {
+          rule += ' (' + message.ruleId + ')';
+        }
 
-      logger.log(state[type].logType, '%d:%d\t' +
-        state[type].color(type) + '\t %s',
-        message.line, message.column, rule);
-    });
+        logger.log(state[type].logType, '%d:%d\t' +
+          state[type].color(type) + '\t %s',
+          message.line, message.column, rule);
+      });
+    }
   }
 };
 

--- a/lib/lint/reporters/eslint.js
+++ b/lib/lint/reporters/eslint.js
@@ -4,8 +4,14 @@ var _ = require('lodash'),
   logger = require('winston'),
   EOL = require('os').EOL,
   state = {
-    error: chalk.red,
-    warning: chalk.cyan
+    error: {
+      color: chalk.red,
+      logType: 'error'
+    },
+    warning: {
+      color: chalk.yellow,
+      logType: 'warn'
+    }
   };
 
 var reporter = {
@@ -15,11 +21,22 @@ var reporter = {
    * @param message {object} the eslint results.
    * @param name {string} The name of the module.
    */
-  report: function(messages, name) {
-    _.forEach(messages, function(message) {
-        var text = 'ESLint - ' + name + ' : (line: %d, column: %d) rule: %s - %s',
-          type = message.fatal? 'error' : 'warning';
-        logger.error(state[type](text) + EOL + chalk.magenta('source: %s'), message.line, message.column, message.message, message.ruleId, message.source);
+  report: function (messages, name) {
+    console.log();
+    logger.info(chalk.cyan('ESLint: ' + name));
+    _.forEach(messages, function (message) {
+      var rule, type = message.severity > 1 ? 'error' : 'warning';
+
+      if (message.message && message.message.trim().length) {
+        rule = message.message;
+      }
+      if (message.ruleId && message.ruleId.trim().length) {
+        rule += ' (' + message.ruleId + ')';
+      }
+
+      logger.log(state[type].logType, '%d:%d\t' +
+        state[type].color(type) + '\t %s',
+        message.line, message.column, rule);
     });
   }
 };


### PR DESCRIPTION
- Removed source - too noisy (user can run eslint manually)
- Simpler coloring scheme
- Only display message and/or ruleId if they exist
- Fix test on message.fatal to severity for coloring/logging purposes

Can you merge that ASAP @jrubstein ? Thanks!