### PR TITLE
Fixing copy issues with non-text files

### DIFF
--- a/lib/utils/copier.js
+++ b/lib/utils/copier.js
@@ -27,7 +27,7 @@ module.exports = {
             outputPath = path.join(destination, relativePath);
           mkdirp.sync(path.dirname(outputPath));
           // Copy the file.
-          fs.createReadStream(source).pipe(fs.createWriteStream(outputPath));
+          fs.writeFileSync(outputPath, fs.readFileSync(source));
         });
     });
   },

--- a/lib/utils/copier.js
+++ b/lib/utils/copier.js
@@ -27,7 +27,7 @@ module.exports = {
             outputPath = path.join(destination, relativePath);
           mkdirp.sync(path.dirname(outputPath));
           // Copy the file.
-          fs.writeFileSync(outputPath, fs.readFileSync(source, 'utf8'));
+          fs.createReadStream(source).pipe(fs.createWriteStream(outputPath));
         });
     });
   },


### PR DESCRIPTION
The copy utility corrupts the destination file, if the file has non-text content like webfonts (ttf), images ... Removing `utf8` encoding to seamlessly copy files irrespective of the file content.