### PR TITLE
PN-15077 | Fixing 'YUI CSS Detection Stamp' implementation.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -498,7 +498,7 @@ var builder = {
         skinContent = fs.readFileSync(currentSkin);
         content = core + EOL + skinContent;
         // Build the css files.
-        builder.buildCss(content, targetPath, filename, name, properties);
+        builder.buildCss(content, targetPath, filename, name, properties, skin);
       } else {
         LOG.debug('%s does not exist', currentSkin);
       }
@@ -537,10 +537,11 @@ var builder = {
    * @param targetPath {string} The output path for the module.
    * @param filename {string} The name for the output file.
    * @param moduleName {string} The name of the module.
-   * @param properties {obejct} The properties for the module.
+   * @param properties {object} The properties for the module.
+   * @param skinName {string} The name of the skin. Optional for css module.
    * @param callback {function} The callback to be called with the results.
    */
-  buildCss: function (data, targetPath, filename, moduleName, properties, callback) {
+  buildCss: function (data, targetPath, filename, moduleName, properties, skinName, callback) {
     // Replace all the ```replace--XXX``` properties.
     var content = replace(data, properties.replace),
       valid;
@@ -557,7 +558,8 @@ var builder = {
     // Wrap the content with the ```css``` files to be compatibility with ```shifter```.
     content = templates.css({
       body: content,
-      name: moduleName
+      name: moduleName,
+      skin: skinName
     });
 
     if (!config.dry) {

--- a/lib/templates/css.dot
+++ b/lib/templates/css.dot
@@ -1,4 +1,8 @@
 {{= it.body}}
 
 /* YUI CSS Detection Stamp */
+{{? it.skin}}
+#yui3-css-stamp.skin-{{= it.skin}}-{{= it.name}} { display: none; }
+{{??}}
 #yui3-css-stamp.{{= it.name}} { display: none; }
+{{?}}


### PR DESCRIPTION
Unicorn is appending incorrect 'css detection' styles to the module css skin file, breaking the 'YUI CSS Detection Stamp' feature resulting the Loader to fetch css assets once again which are already loaded in the page via wt2 tags.


**Shifter** - generated
```css
#yui3-css-stamp.skin-nx-wf2-base-css{display:none}
```
**Unicorn** - generated
```css
#yui3-css-stamp.wf2-base-css{display:none} /*.skin-nx prefix is missing*/
```